### PR TITLE
Fix the mutation error which occurs if the amount from another variant is changed

### DIFF
--- a/pages/_category/_product.vue
+++ b/pages/_category/_product.vue
@@ -109,16 +109,17 @@ export default {
   methods: {
     addToCart(product, variant) {
       if (variant.model > 0) {
+        // Create a deep copy to not changing the model attribute of another variant, which changes the entry outside of a mutation
         const entry = {
-          product,
-          variant,
+          product: JSON.parse(JSON.stringify(product)),
+          variant: JSON.parse(JSON.stringify(variant)),
           amount: variant.model
         }
 
         this.$store.commit('shoppingCart/addEntry', entry)
 
         this.$buefy.toast.open({
-          message: 'Produkt wurde hinzugefüt.',
+          message: 'Produkt wurde hinzugefügt.',
           type: 'is-success'
         })
       } else {


### PR DESCRIPTION
Hi @Lukas220300!
After fixing the product rendering bug, which causes more then one product variant to be rendered on one product page, the following happens:
If one adds a variant to the card and changes the amount of another variant, a vuex mutation exception occurs because the product is send to the vuex store by reference. And the two variants, and therefore the amount, change in the vuex store if they get changed on the ui by vue. To fix this, I deeply copied the objects.
Please have a look!
Thanks,
Flo